### PR TITLE
New doccord style

### DIFF
--- a/hoon-mode.el
+++ b/hoon-mode.el
@@ -310,8 +310,7 @@ be a simple regular expression because we need to check the ppss."
        (let ((c (buffer-substring-no-properties (nth 8 state)
                                                 (+ (nth 8 state) 2))))
          (or (string= c ":<")
-             (string= c ":>")
-             (string= c ":~")))))
+             (string= c ":>")))))
 
 (defun hoon-font-lock-syntactic-face-function (state)
   "Return syntactic face given STATE."

--- a/hoon-mode.el
+++ b/hoon-mode.el
@@ -48,9 +48,21 @@
     (modify-syntax-entry ?: ". 12b" st)
     (modify-syntax-entry ?\n "> b" st)
 
-    ;; todo: i don't understand why this is here.
+    ;; Dash is the only 'symbol' in hoon; in Emacs, symbols are characters
+    ;; which can be combined with the 'word' syntax class to form identifiers.
+    (modify-syntax-entry ?- "_" st)
+
+    ;; Put all other characters which could be part of a rune in the
+    ;; punctuation class.
+    (modify-syntax-entry ?! "." st)
+    (modify-syntax-entry '(?\# . ?\&) "." st)
+    (modify-syntax-entry '(?* . ?\,) "." st)
+    (modify-syntax-entry '(?. . ?/) "." st)
+    ;; Note: : is defined in the comment definition above.
+    (modify-syntax-entry '(?\; . ?@) "." st)
+    (modify-syntax-entry '(?^ . ?_) "." st)
     (modify-syntax-entry ?| "." st)
-    (modify-syntax-entry ?\; "." st)
+    (modify-syntax-entry ?~ "." st)
     st)
   "Syntax table for `hoon-mode'.")
 

--- a/hoon-mode.el
+++ b/hoon-mode.el
@@ -45,12 +45,11 @@
     (modify-syntax-entry ?\" "\"" st)
     (modify-syntax-entry ?\\ "\\" st)
     ;; Hoon comments. All these are normal punctuation characters, but ':'
-    ;; starts a two-character comment psuedorune, and '<', '>' and '~' can be
+    ;; starts a two-character comment psuedorune, and ':', '<', and'>' can be
     ;; the second character in that sequence.
     (modify-syntax-entry ?: ". 12b" st)
     (modify-syntax-entry ?< ". 2b" st)
     (modify-syntax-entry ?> ". 2b" st)
-    (modify-syntax-entry ?~ ". 2b" st)
     ;; Terminate hoon comments at the end of lines.
     (modify-syntax-entry ?\n "> b" st)
 
@@ -64,7 +63,8 @@
     (modify-syntax-entry '(?\# . ?\&) "." st)
     (modify-syntax-entry '(?* . ?\,) "." st)
     (modify-syntax-entry '(?. . ?/) "." st)
-    ;; Note: ':', '<', '>' and '~' are defined in the comment definition above.
+    ;; Note: ':', '<', and '>' are defined in the comment definition above.
+    (modify-syntax-entry ?~ "." st)
     (modify-syntax-entry ?\; "." st)
     (modify-syntax-entry ?= "." st)
     (modify-syntax-entry ?\? "." st)


### PR DESCRIPTION
This PR removes the old `''':` doccord syntax and moves to the new `:>` syntax. There isn't a sample yet so I tried to make one. It can fontify the following code sample.

(If the syntax in this sample is wrong, this PR probably needs further work.)

```
:>  layer one: basic arithmetic, tree addressing and molds.
|%
:~  1a: unsigned arithmetic
++  add
  :>  unsigned addition
  :>
  :>  produces the sum of `a` and `b`.
  ~/  %add
  |=  {a/@ b/@}
  ^-  @
  ?:  =(0 a)  b
  $(a (dec a), b +(b))
::
:~  1b: tree addressing
++  cap
  :>  tree head.
  :>
  :>  tests whether an `a` is in the head or tail of a noun. produces the
  :>  cube `%2` if it is within the head, or the cube `%3` if it is
  :>  within the tail.
  ~/  %cap
  |=  a/@
  ^-  ?($2 $3)
  ?-  a
    $2        %2
    $3        %3
    ?($0 $1)  !!
    *         $(a (div a 2))
  ==
::
--
```