### PR TITLE
Various fixups

### DIFF
--- a/hoon-mode.el
+++ b/hoon-mode.el
@@ -48,9 +48,19 @@
     (modify-syntax-entry ?: ". 12b" st)
     (modify-syntax-entry ?\n "> b" st)
 
-    ;; todo: i don't understand why this is here.
+    ;; Add dash to the symbol class since it can be part of identifier.
+    (modify-syntax-entry ?- "_" st)
+
+    ;; Put all other characters which can be part of runes in the punctuation
+    ;; class so that forward and backward work properly.
+    (modify-syntax-entry ?! "." st)
+    (modify-syntax-entry '(?\# . ?\&) "." st)
+    (modify-syntax-entry '(?* . ?\,) "." st)
+    (modify-syntax-entry '(?. . ?/) "." st)
+    (modify-syntax-entry '(?\; . ?@) "." st)
+    (modify-syntax-entry '(?^ . ?_) "." st)
     (modify-syntax-entry ?| "." st)
-    (modify-syntax-entry ?\; "." st)
+    (modify-syntax-entry ?~ "." st)
     st)
   "Syntax table for `hoon-mode'.")
 

--- a/hoon-mode.el
+++ b/hoon-mode.el
@@ -172,22 +172,6 @@ regexp. Because of =/, this rule must run after the normal mold rule.")
   (rx "!!")
   "Highlight the crash rune in red.")
 
-(defun hoon-font-match-comment-code-matcher (end)
-  "Search for embedded `markdown code` in string types which
-should be highlighted. This check ensures that both the ` marks
-occur inside some sort of string."
-  (let ((pos 0)
-        (end-pos 0))
-    (cond ((and (setq pos (search-forward "`" end t))
-                (nth 3 (syntax-ppss pos)))
-           (let ((beg (match-beginning 0)))
-             (cond ((and (setq end-pos (search-forward "`" end t))
-                         (nth 3 (syntax-ppss end-pos)))
-                    (set-match-data (list beg (point)))
-                    t)
-                   (t nil))))
-          (t nil))))
-
 (defconst hoon-font-lock-numbers-rx
   ;; Numbers are in decimal, binary, hex, base32, or base64, and they must
   ;; contain dots (optionally followed by whitespace), as in the German manner.
@@ -243,9 +227,6 @@ occur inside some sort of string."
     (,hoon-font-lock-preprocessor-rx . font-lock-preprocessor-face)
     (,hoon-font-lock-zapzap-rx . font-lock-warning-face)
 
-    ;; Highlight mini-markdown.
-    (hoon-font-match-comment-code-matcher 0 font-lock-constant-face t)
-
     ;; Highlight any auras in any other contexts. This must happen after all
     ;; the above because it would otherwise stop the previous rules' execution.
     ;; TODO: This rule causes false positives, highlighting ^ in contexts where
@@ -261,47 +242,6 @@ occur inside some sort of string."
 
 (defvar hoon-outline-regexp ":::")
 
-(defun hoon-info-docstring-p (state)
-  "Return non-nil if point is in a docstring."
-  (and (nth 3 state)
-       (nth 8 state)
-       (string=
-        (buffer-substring-no-properties (nth 8 state) (+ (nth 8 state) 4))
-        "''':")))
-
-(defun hoon-font-lock-syntactic-face-function (state)
-  "Return syntactic face given STATE."
-  (if (nth 3 state)
-      (if (hoon-info-docstring-p state)
-          font-lock-doc-face
-        font-lock-string-face)
-    font-lock-comment-face))
-
-(defun hoon-syntax-stringify ()
-  "Put `syntax-table' property correctly on doccords. Adapted
-from `python-syntax-stringify', which does a similar trick."
-  (let* ((num-quotes (length (match-string-no-properties 1)))
-         (ppss (prog2
-                   (backward-char num-quotes)
-                   (syntax-ppss)
-                 (forward-char num-quotes)))
-         (string-start (and (not (nth 4 ppss)) (nth 8 ppss)))
-         (quote-starting-pos (- (point) num-quotes))
-         (quote-ending-pos (point)))
-    (if (not string-start)
-        ;; This set of quotes delimit the start of a string.
-        (put-text-property quote-starting-pos (1+ quote-starting-pos)
-                           'syntax-table (string-to-syntax "|"))
-      ;; This set of quotes delimit the end of a string.
-      (put-text-property (1- quote-ending-pos) quote-ending-pos
-                         'syntax-table (string-to-syntax "|")))))
-
-(defconst hoon-syntax-propertize-function
-  (syntax-propertize-rules
-   ((rx (group "''':"))
-    (0 (ignore (hoon-syntax-stringify)))))
-  "Modify the syntax table so we deal with multiline doccords.")
-
 ;;;###autoload
 (define-derived-mode hoon-mode prog-mode "Hoon"
   "A major mode for editing Hoon files."
@@ -312,19 +252,13 @@ from `python-syntax-stringify', which does a similar trick."
   (set (make-local-variable 'comment-column) 56)   ;; zero based columns
   (set (make-local-variable 'comment-use-syntax) t)
   (set (make-local-variable 'comment-start-skip) "\\(::+\\)\\s-*")
-  (set (make-local-variable 'font-lock-defaults)
-       '(hoon-font-lock-keywords
-         nil nil nil nil
-         (font-lock-syntactic-face-function
-          . hoon-font-lock-syntactic-face-function)))
+  (set (make-local-variable 'font-lock-defaults) '(hoon-font-lock-keywords))
   (set (make-local-variable 'indent-tabs-mode) nil) ;; tabs zutiefst verboten
   (set (make-local-variable 'indent-line-function) 'indent-relative)
   (set (make-local-variable 'fill-paragraph-function) 'hoon-fill-paragraph)
   (set (make-local-variable 'imenu-generic-expression)
        hoon-imenu-generic-expression)
   (set (make-local-variable 'outline-regexp) hoon-outline-regexp)
-  (set (make-local-variable 'syntax-propertize-function)
-       hoon-syntax-propertize-function)
 
   ;; Hoon files often have the same file name in different
   ;; directories. Previously, this was manually handled by hoon-mode instead of


### PR DESCRIPTION
This is the first of several patches to get the Emacs config files in order for eventual inclusion in the [MELPA](https://melpa.org/#/) repository, allowing any `package.el` user to install hoon-mode.el.

This first fixes up the syntax table to not be a garbage fire, and reverts the last vestiges of the `''':` doccord syntax which hasn't been a valid thing for over a year now.

@keatondunsford 