### PR TITLE
Resolve quoting problems with sending code to urb

### DIFF
--- a/hoon-mode.el
+++ b/hoon-mode.el
@@ -318,16 +318,16 @@ form syntax, but that would take parsing.)"
 (defun eval-region-in-urb ()
   (interactive)
   (shell-command
-   (concat hoon-urb-path " " hoon-urb-args " \""
-	   (buffer-substring (region-beginning) (region-end))
-	   "\" &")))
+   (concat hoon-urb-path " " hoon-urb-args " "
+	   (shell-quote-argument (buffer-substring (region-beginning) (region-end)))
+	   " &")))
 
 (defun eval-buffer-in-urb ()
   (interactive)
   (shell-command
-   (concat hoon-urb-path " " hoon-urb-args " \""
-	   (buffer-substring-no-properties (point-min) (point-max))
-	   "\" &")))
+   (concat hoon-urb-path " " hoon-urb-args " "
+	   (shell-quote-argument (buffer-substring-no-properties (point-min) (point-max)))
+	   " &")))
 
 (define-key hoon-mode-map (kbd "C-c r") 'eval-region-in-urb)
 


### PR DESCRIPTION
Sometimes when sending code to urb, bash would attempt to interpret
the code instead of just sending it along. I tried multiple different
techniques for fixing this and had to fall back to the emacs
shell-quote-argument method. The downside is that the exact command
send to urb is difficult to examine, but it does maintain
asynchronicity which is important for me not throwing my computer out
the window. The difficulty of examining the command should not be a
problem in day to day use as you will be examining your code rather
than the input to urb.