### PR TITLE
Prepare for inclusion into Melpa

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,16 @@
+This package provides `hoon-mode`, which provides syntax highlighting
+for the language Hoon which is part of the [Urbit](https://urbit.org)
+ecosystem.
+
+
+## Installing
+Currently this package must be installed manually.
+
+
+## Configuring
+Add the following to your configuration:
+
+	(add-hook 'hoon-mode
+	          (lambda ()
+	            (define-key hoon-mode-map (kbd "C-c r") 'hoon-eval-region-in-urb)
+	            (define-key hoon-mode-map (kbd "C-c b") 'hoon-eval-buffer-in-urb)))

--- a/hoon-mode.el
+++ b/hoon-mode.el
@@ -3,13 +3,14 @@
 ;; Copyright (C) 2014–2016 Urbit
 
 ;; Author:
-;;    * Adam Bliss      https://github.com/abliss          <abliss@gmail.com>
+;;    * Adam Bliss        https://github.com/abliss         <abliss@gmail.com>
 ;; Contributors:
-;;    * N Gvrnd         https://github.com/ngvrnd
-;;    * TJamesCorcoran  https://github.com/TJamesCorcoran <jamescorcoran@gmail.com>
-;;    * Rastus Vernon   https://github.com/rastus-vernon  <rastus.vernon@protonmail.ch>
-;;    * Elliot Glaysher https://github.com/eglaysher      <erg@google.com>
-;;    * David Kerschner https://github.com/baudtack      <dkerschner@hcoop.net>
+;;    * N Gvrnd           https://github.com/ngvrnd
+;;    * TJamesCorcoran    https://github.com/TJamesCorcoran <jamescorcoran@gmail.com>
+;;    * Rastus Vernon     https://github.com/rastus-vernon  <rastus.vernon@protonmail.ch>
+;;    * Elliot Glaysher   https://github.com/eglaysher      <erg@google.com>
+;;    * David Kerschner   https://github.com/baudtack       <dkerschner@hcoop.net>
+;;    * Johnathan Maudlin https://github.com/jcmdln         <jcmdln@gmail.com>
 ;;
 ;; URL: https://github.com/urbit/hoon-mode.el
 ;; Version: 0.1
@@ -315,23 +316,19 @@ form syntax, but that would take parsing.)"
   :group 'hoon
   :type 'string)
 
-(defun eval-region-in-urb ()
+(defun hoon-eval-region-in-urb ()
   (interactive)
   (shell-command
    (concat hoon-urb-path " " hoon-urb-args " "
 	   (shell-quote-argument (buffer-substring (region-beginning) (region-end)))
 	   " &")))
 
-(defun eval-buffer-in-urb ()
+(defun hoon-eval-buffer-in-urb ()
   (interactive)
   (shell-command
    (concat hoon-urb-path " " hoon-urb-args " "
 	   (shell-quote-argument (buffer-substring-no-properties (point-min) (point-max)))
 	   " &")))
-
-(define-key hoon-mode-map (kbd "C-c r") 'eval-region-in-urb)
-
-(define-key hoon-mode-map (kbd "C-c b") 'eval-buffer-in-urb)
 
 (provide 'hoon-mode)
 ;;; hoon-mode.el ends here


### PR DESCRIPTION
These two commits are required to include this package into Melpa, admittedly my preferred package manager for Emacs, in the hopes that others will find this package easier to locate and install in the future. I could request for Melpa to index this package as-is, but this is an attempt to politely align the package with their contributing guidelines. `checkdoc` is complaining about trivialities, though I wasn't moved to act on it's warnings.

ab639ac resolves the following errors generated by `package-lint`:

    318:1: error: "eval-region-in-urb" doesn't start with package's prefix "hoon".
    325:1: error: "eval-buffer-in-urb" doesn't start with package's prefix "hoon".

This was fixed by adding the prefix `hoon-` to each function as the error states. I've also adding myself as a contributor in the header but considering I'm not really adding functionality I'm happy to remove it if desired.


2015a80 resolves the following errors generated by `package-lint`:

    332:60: warning: This key sequence is reserved (see Key Binding Conventions in the Emacs Lisp manual)
    334:60: warning: This key sequence is reserved (see Key Binding Conventions in the Emacs Lisp manual)

This was fixed by moving custom configuration to the newly created README, which contains a quick example for adding a hook for the new mode this package adds. 