### PR TITLE
add support for hoon-language-server

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,3 +14,12 @@ Add the following to your configuration:
 	          (lambda ()
 	            (define-key hoon-mode-map (kbd "C-c r") 'hoon-eval-region-in-herb)
 	            (define-key hoon-mode-map (kbd "C-c b") 'hoon-eval-buffer-in-herb)))
+
+### Language Server
+Install the [Hoon Language
+Server](https://github.com/urbit/hoon-language-server)
+and add the following to your configuration
+``` emacs-lisp
+(add-hook 'hoon-mode #'lsp)
+```
+

--- a/hoon-mode.el
+++ b/hoon-mode.el
@@ -353,6 +353,27 @@ form syntax, but that would take parsing.)"
   :group 'hoon
   :type 'string)
 
+(defcustom hoon-lsp-enable nil
+  "Enable hoon-language-server support. NOTE: requires lsp-mode and hoon-language-server to be installed"
+  :group 'hoon
+  :type 'boolean)
+
+(defcustom hoon-lsp-args ""
+  "args for language server"
+  :group 'hoon
+  :type 'string)
+
+(eval-after-load "lsp-mode"
+  (if hoon-lsp-enable
+    '(progn
+      (add-to-list 'lsp-language-id-configuration '(hoon-mode . "hoon"))
+      (lsp-register-client
+        (make-lsp-client :new-connection (lsp-stdio-connection "hoon-language-server")
+                         :major-modes '(hoon-mode)
+                         :server-id 'hoon-ls))
+      (add-hook 'hoon-mode-hook #'lsp))
+  '()))
+
 (defun hoon-eval-region-in-herb ()
   (interactive)
   (shell-command


### PR DESCRIPTION
Adds support for hoon-language-server through lsp-mode. Requires
hoon-language-server and lsp-mode to be installed.